### PR TITLE
feat(api): add endpoints for employee management and scheduling

### DIFF
--- a/app/api/addemp/route.js
+++ b/app/api/addemp/route.js
@@ -1,0 +1,27 @@
+import { addEmployee } from "@/app/lib/util";
+import { NextResponse } from "next/server";
+
+export async function POST(req){
+    try{
+        const data = await req.json();
+        const name = data?.name;
+
+        await addEmployee(name);
+        return new NextResponse(JSON.stringify({ message: "Success" }),{
+            status: 200,
+            headers: {
+                "Content-Type": "application/json",
+            },
+        });
+
+    }
+    catch(e){
+        console.log(e);
+        return new NextResponse(JSON.stringify({ message: "Error" }),{
+            headers: {
+                code: 500,
+                "Content-Type": "application/json",
+            },
+        });
+    }
+}

--- a/app/api/getorg/route.js
+++ b/app/api/getorg/route.js
@@ -1,0 +1,23 @@
+import { getOrganization } from "@/app/lib/util";
+import { NextResponse } from "next/server";
+
+export async function GET(req){
+    try{
+        const response = await getOrganization();
+        return new NextResponse(JSON.stringify(response),{
+            status: 200,
+            headers: {
+                "Content-Type": "application/json",
+            },
+        });        
+    }
+    catch(e){
+        console.log(e);
+        return new NextResponse(JSON.stringify({ message: "Error" }),{
+            headers: {
+                code: 500,
+                "Content-Type": "application/json",
+            },
+        });
+    }
+}

--- a/app/lib/util.jsx
+++ b/app/lib/util.jsx
@@ -19,12 +19,10 @@ export async function getOrganization(){
     // const docRef = doc(db, "Organizations", organization);
     const colRef = query(collection(db, "Organizations"))
     const docSnap = await getDocs(colRef);
-
-    return docSnap;
-
-    // if(docSnap.exists()){
-    //     console.log(docSnap.data());
-    // }else{
-    //     console.log("No data");
-    // }
+    const orgs = [];
+    docSnap.forEach((doc) => {
+        const data = doc.data();
+        orgs.push(data);
+    })
+    return orgs;
 }


### PR DESCRIPTION
POST /addemp: Adds a new employee to the database

GET /getorg: Retrieves organization details from the database.

POST /schedule: Calls the OR microservice to generate employee schedules

EDIT: Modified the `getOrganization` from `lib\utils.jsx` for returning `.data`